### PR TITLE
Return to Apache license for dendrite work

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,5 +16,5 @@
 
 bin
 .vscode
-log
+./log
 .DS_Store

--- a/appservice/consumers/roomserver.go
+++ b/appservice/consumers/roomserver.go
@@ -1,16 +1,19 @@
-// Copyright (C) 2020 Finogeeks Co., Ltd
+// Copyright 2017 Vector Creations Ltd
 //
-// This program is free software: you can redistribute it and/or  modify
-// it under the terms of the GNU Affero General Public License, version 3,
-// as published by the Free Software Foundation.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+// Modifications copyright (C) 2020 Finogeeks Co., Ltd
 
 package consumers
 

--- a/common/httpapi.go
+++ b/common/httpapi.go
@@ -1,16 +1,19 @@
-// Copyright (C) 2020 Finogeeks Co., Ltd
+// Copyright 2017 Vector Creations Ltd
 //
-// This program is free software: you can redistribute it and/or  modify
-// it under the terms of the GNU Affero General Public License, version 3,
-// as published by the Free Software Foundation.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+// Modifications copyright (C) 2020 Finogeeks Co., Ltd
 
 package common
 

--- a/federation/fedsender/queue/destinationqueue.go
+++ b/federation/fedsender/queue/destinationqueue.go
@@ -1,16 +1,19 @@
-// Copyright (C) 2020 Finogeeks Co., Ltd
+// Copyright 2017 Vector Creations Ltd
 //
-// This program is free software: you can redistribute it and/or  modify
-// it under the terms of the GNU Affero General Public License, version 3,
-// as published by the Free Software Foundation.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+// Modifications copyright (C) 2020 Finogeeks Co., Ltd
 
 package queue
 

--- a/federation/fedsender/queue/queue.go
+++ b/federation/fedsender/queue/queue.go
@@ -1,16 +1,19 @@
-// Copyright (C) 2020 Finogeeks Co., Ltd
+// Copyright 2017 Vector Creations Ltd
 //
-// This program is free software: you can redistribute it and/or  modify
-// it under the terms of the GNU Affero General Public License, version 3,
-// as published by the Free Software Foundation.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+// Modifications copyright (C) 2020 Finogeeks Co., Ltd
 
 package queue
 

--- a/model/authtypes/logintypes.go
+++ b/model/authtypes/logintypes.go
@@ -1,20 +1,23 @@
-// Copyright (C) 2020 Finogeeks Co., Ltd
+// Copyright 2017 Vector Creations Ltd
 //
-// This program is free software: you can redistribute it and/or  modify
-// it under the terms of the GNU Affero General Public License, version 3,
-// as published by the Free Software Foundation.
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
 //
-// This program is distributed in the hope that it will be useful,
-// but WITHOUT ANY WARRANTY; without even the implied warranty of
-// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
-// GNU Affero General Public License for more details.
+//     http://www.apache.org/licenses/LICENSE-2.0
 //
-// You should have received a copy of the GNU Affero General Public License
-// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+//
+//
+// Modifications copyright (C) 2020 Finogeeks Co., Ltd
 
 package authtypes
 
-// The relevant login types implemented in Dendrite
+// The relevant login types implemented in Ligase
 const (
 	LoginTypeDummy        = "m.login.dummy"
 	LoginTypeSharedSecret = "org.matrix.login.shared_secret"


### PR DESCRIPTION
### Pull Request Checklist

<!-- Please read CONTRIBUTING.md before submitting your pull request -->

* [ ] Pull request is based on the develop branch


<!-- Thank you for contributing to Ligase!

PR Title Format:
1. *: what's changed

-->

### What problem does this PR solve?

Issue Number: close #27   <!-- REMOVE this line if no issue to close -->

Problem Summary:

There are some code which is derived from dendrite work and they were mistakenly regarded as Ligase new work. Therefore they use wrong license.

### What is changed and how it works?

What's Changed:

We change APGL 3 license to Apache 2 license for those code.

How it Works:

We used script to compare the name of code in Ligase codebase to dendrite codebase and picked out those who has the same name. Then we carefully compare those scripts to make sure that no script derived from dendrite using wrong license.
