### PR TITLE
adjust syncapi db index

### DIFF
--- a/storage/implements/syncapi/client_data_table.go
+++ b/storage/implements/syncapi/client_data_table.go
@@ -17,10 +17,11 @@ package syncapi
 import (
 	"context"
 	"database/sql"
+
 	"github.com/finogeeks/ligase/common"
-	log "github.com/finogeeks/ligase/skunkworks/log"
 	"github.com/finogeeks/ligase/model/dbtypes"
 	"github.com/finogeeks/ligase/model/types"
+	log "github.com/finogeeks/ligase/skunkworks/log"
 )
 
 const clientDataStreamSchema = `
@@ -43,8 +44,6 @@ CREATE TABLE IF NOT EXISTS syncapi_client_data_stream (
     CONSTRAINT syncapi_client_data_stream_unique UNIQUE (user_id, room_id, data_type, stream_type)
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS syncapi_client_data_stream_id_idx ON syncapi_client_data_stream(id);
-CREATE INDEX IF NOT EXISTS syncapi_client_data_user_id_idx ON syncapi_client_data_stream(user_id);
 `
 
 const insertClientDataStreamSQL = "" +

--- a/storage/implements/syncapi/current_room_state_table.go
+++ b/storage/implements/syncapi/current_room_state_table.go
@@ -23,8 +23,8 @@ import (
 
 	"github.com/finogeeks/ligase/common"
 	"github.com/finogeeks/ligase/common/encryption"
-	"github.com/finogeeks/ligase/skunkworks/gomatrixserverlib"
 	"github.com/finogeeks/ligase/model/dbtypes"
+	"github.com/finogeeks/ligase/skunkworks/gomatrixserverlib"
 	"github.com/lib/pq"
 )
 
@@ -52,9 +52,8 @@ CREATE TABLE IF NOT EXISTS syncapi_current_room_state (
 );
 -- for event deletion
 CREATE UNIQUE INDEX IF NOT EXISTS syncapi_rs_event_id_idx ON syncapi_current_room_state(event_id);
-CREATE INDEX IF NOT EXISTS syncapi_current_rooom_id_idx ON syncapi_current_room_state(room_id);
 -- for querying membership states of users
-CREATE INDEX IF NOT EXISTS syncapi_membership_idx ON syncapi_current_room_state(type, state_key, membership) WHERE membership IS NOT NULL AND membership != 'leave';
+CREATE INDEX IF NOT EXISTS syncapi_membership_idx ON syncapi_current_room_state(state_key, type, membership);
 `
 
 const upsertRoomStateSQL = "" +

--- a/storage/implements/syncapi/receipt_data_table.go
+++ b/storage/implements/syncapi/receipt_data_table.go
@@ -17,10 +17,11 @@ package syncapi
 import (
 	"context"
 	"database/sql"
+
 	"github.com/finogeeks/ligase/common"
-	log "github.com/finogeeks/ligase/skunkworks/log"
 	"github.com/finogeeks/ligase/model/dbtypes"
 	"github.com/finogeeks/ligase/model/types"
+	log "github.com/finogeeks/ligase/skunkworks/log"
 	"github.com/lib/pq"
 )
 
@@ -36,11 +37,9 @@ CREATE TABLE IF NOT EXISTS syncapi_receipt_data_stream (
     room_id TEXT NOT NULL,
 	content TEXT NOT NULL,
  
-    CONSTRAINT syncapi_receipt_data_stream_unique UNIQUE (id, room_id)
+    CONSTRAINT syncapi_receipt_data_stream_unique UNIQUE (room_id, id)
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS syncapi_receipt_data_stream_id_idx ON syncapi_receipt_data_stream(id);
-CREATE INDEX  IF NOT EXISTS syncapi_load_room_receipt_data_stream ON syncapi_receipt_data_stream (room_id);
 `
 
 const insertReceiptDataStreamSQL = "" +

--- a/storage/implements/syncapi/send_to_device_table.go
+++ b/storage/implements/syncapi/send_to_device_table.go
@@ -17,11 +17,12 @@ package syncapi
 import (
 	"context"
 	"database/sql"
+
 	"github.com/finogeeks/ligase/common"
-	log "github.com/finogeeks/ligase/skunkworks/log"
 	"github.com/finogeeks/ligase/model/dbtypes"
 	"github.com/finogeeks/ligase/model/syncapitypes"
 	"github.com/finogeeks/ligase/model/types"
+	log "github.com/finogeeks/ligase/skunkworks/log"
 )
 
 // we treat send to device as abbrev as STD in the context below.
@@ -39,8 +40,7 @@ CREATE TABLE IF NOT EXISTS syncapi_send_to_device (
 CONSTRAINT syncapi_send_to_device_unique UNIQUE (id, target_device_id, target_user_id)
 );
 
-CREATE UNIQUE INDEX IF NOT EXISTS syncapi_send_to_device_stream_id_idx ON syncapi_send_to_device(id);
-CREATE INDEX IF NOT EXISTS syncapi_send_to_device_device_id_idx ON syncapi_send_to_device(target_device_id, target_user_id);
+CREATE INDEX IF NOT EXISTS syncapi_send_to_device_user_id_device_id_id_desc_idx ON syncapi_send_to_device(target_user_id,target_device_id, id desc nulls last);
 `
 
 const insertSTDSQL = "" +

--- a/storage/implements/syncapi/user_receipt_data_table.go
+++ b/storage/implements/syncapi/user_receipt_data_table.go
@@ -17,9 +17,10 @@ package syncapi
 import (
 	"context"
 	"database/sql"
+
 	"github.com/finogeeks/ligase/common"
-	log "github.com/finogeeks/ligase/skunkworks/log"
 	"github.com/finogeeks/ligase/model/dbtypes"
+	log "github.com/finogeeks/ligase/skunkworks/log"
 )
 
 const userReceiptDataSchema = `
@@ -33,8 +34,6 @@ CREATE TABLE IF NOT EXISTS syncapi_user_receipt_data (
  
     CONSTRAINT syncapi_user_receipt_data_unique UNIQUE (user_id, room_id)
 );
-
-CREATE INDEX IF NOT EXISTS syncapi_user_receipt_data_idx ON syncapi_user_receipt_data(user_id, room_id);
 `
 
 const insertUserReceiptDataSQL = "" +


### PR DESCRIPTION
### What is changed and how it works?

What's Changed and How it Works:
1. Remove duplicated indexes according some facts of pg:

- primary key will auto create a unique index
- Adding a unique constraint will automatically create a unique B-tree index on the column or group of columns listed in the constraint
-  if combination index (A, B, C) exists, (A), (A, B) is on longer needed

2. improve query:
```sql
SELECT room_id, added_at, event_id FROM syncapi_current_room_state WHERE type = 'm.room.member' AND state_key = $1 AND membership = ANY('{leave, ban}')
```
because the index exclude the 'leave' rows, so pg will query more rows to filter

```sql
CREATE INDEX IF NOT EXISTS syncapi_membership_idx ON syncapi_current_room_state(type, state_key, membership) WHERE membership IS NOT NULL AND membership != 'leave';

to 

CREATE INDEX IF NOT EXISTS syncapi_membership_idx ON syncapi_current_room_state(state_key, type, membership);
```

3. improve query:
```sql
SELECT id, sender, event_type, event_json FROM syncapi_send_to_device  WHERE target_user_id = $1 AND target_device_id = $2 ORDER BY id DESC LIMIT $3;
```

add index 
```sql
CREATE INDEX IF NOT EXISTS syncapi_send_to_device_user_id_device_id_id_desc_idx ON syncapi_send_to_device(target_user_id,target_device_id, id desc nulls last);
```